### PR TITLE
Fix live view for Nikon DSLRs; Add option for inter-shot delay

### DIFF
--- a/include/camera.h
+++ b/include/camera.h
@@ -77,6 +77,7 @@ namespace ols {
         opt_viewfinder,
         opt_capturetarget,
         opt_keep_images,
+        opt_capture_delay,
         /// Android
         opt_zoom,
         /// External non-device specific options start HERE!

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -86,13 +86,13 @@ std::ostream &operator<<(std::ostream &out,CamStreamFormat const &fmt)
 
 static char const *option_string_ids[] = {
     "auto_exp", "auto_wb", "auto_focus", "exp", "wb", "wb_r", "wb_b", "focus", "gain", "gamma", "brightness","contrast", "temperature", "cooler_target","cooler_on", "fan_on", "cooler_power","average_bin","black_level","conv_gain_hcg","conv_gain_hdr","low_noise","high_fullwell", 
-    "iso", "shutter", "viewfinder", "capturetarget", "keep_images",
+    "iso", "shutter", "viewfinder", "capturetarget", "keep_images", "capture_delay",
     "zoom",
     "live_stretch"
 };
 static char const *option_names[] = {
     "Auto Exp.", "Auto WB", "Auto Focus", "Exp.", "WB", "WB Red", "WB Blue", "Focus", "Gain", "Gamma", "Bright.", "Contr.", "Temp.", "Cooler Tgt.", "Cooler", "Fan","Cooler Pwr.","Avg. Bin","Black Lvl.","ConvGain L-0/H-1","ConvGain Lcg-0/Hcg-1/Hdr-2","Low Noise","High Fullwell",
-    "ISO", "Shutter", "View Finder" , "Capture Target", "Keep Images",
+    "ISO", "Shutter", "View Finder" , "Capture Target", "Keep Images", "Inter-Shot Delay",
     "Zoom",
     "Auto Str."
 };

--- a/src/gphoto2_camera.cpp
+++ b/src/gphoto2_camera.cpp
@@ -352,7 +352,10 @@ namespace ols {
                     break;
                 case GP_EVENT_CAPTURE_COMPLETE:
                     LOG("EV:Capture Done\n");
-                    return fno;
+                    if (fno > 0 || stop_) {
+                        return fno;
+                    }
+                    break;
                 default:
                     LOG("EV:Other %d\n",int(ev));
                     break;
@@ -526,11 +529,7 @@ namespace ols {
                 trigger();
                 while(true) {
                     CameraFilePath files[MAX_FILES];
-                    int N = 0;
-                    // don't move on until we actually get the files
-                    while (N == 0 && !stop_) {
-                        N = wait_event(files);
-                    }
+                    int N = wait_event(files);
                     if(stop_) {
                         break;
                     }

--- a/src/gphoto2_camera.cpp
+++ b/src/gphoto2_camera.cpp
@@ -525,7 +525,11 @@ namespace ols {
                 trigger();
                 while(true) {
                     CameraFilePath files[MAX_FILES];
-                    int N = wait_event(files);
+                    int N = 0;
+                    // don't move on until we actually get the files
+                    while (N == 0 && !stop_) {
+                        N = wait_event(files);
+                    }
                     if(stop_) {
                         break;
                     }

--- a/src/gphoto2_camera.cpp
+++ b/src/gphoto2_camera.cpp
@@ -324,6 +324,9 @@ namespace ols {
         {
             int fno = 0;
             while(fno <= 0 || wait_multiple) {
+                if (stop_) {
+                    return fno;
+                }
                 CameraEventType ev = GP_EVENT_UNKNOWN;
                 void *ptr = NULL;
                 int status;
@@ -352,7 +355,7 @@ namespace ols {
                     break;
                 case GP_EVENT_CAPTURE_COMPLETE:
                     LOG("EV:Capture Done\n");
-                    if (fno > 0 || stop_) {
+                    if (fno > 0) {
                         return fno;
                     }
                     break;

--- a/src/gphoto2_camera.cpp
+++ b/src/gphoto2_camera.cpp
@@ -540,10 +540,10 @@ namespace ols {
                     std::thread capture_with_delay([&] {
                         // simple sleep method which allows stopping early
                         for (int i = 0; i < capture_delay_; i++) {
+                            std::this_thread::sleep_for(std::chrono::seconds(1));
                             if (stop_) {
                                 return;
                             }
-                            std::this_thread::sleep_for(std::chrono::seconds(1));
                         }
                         trigger();
                     });

--- a/src/gphoto2_camera.cpp
+++ b/src/gphoto2_camera.cpp
@@ -760,7 +760,7 @@ namespace ols {
             if(!camera_list_.empty()) {
                 return camera_list_;
             }
-	        gp_camera_new(&camera_);
+            gp_camera_new(&camera_);
             int ret = gp_camera_init(camera_,ctx_);
             if(!check(ret,"init",e)) {
                 gp_camera_free(camera_);
@@ -804,7 +804,7 @@ extern "C" {
     void ols_set_gphoto2_driver_log(char const *log_path,int debug)
     {
         ols::error_stream = fopen(log_path,"w");
-	    gp_log_add_func(debug ? GP_LOG_DEBUG : GP_LOG_ERROR , ols::errordumper, NULL);
+        gp_log_add_func(debug ? GP_LOG_DEBUG : GP_LOG_ERROR , ols::errordumper, NULL);
     }
 
 #ifdef ANDROID_SUPPORT


### PR DESCRIPTION
This PR fixes the issue noted in [this discussion](https://github.com/artyom-beilis/OpenLiveStacker/discussions/97) (the live view getting increasingly delayed).

This PR also adds an option to add a delay in between shots for DSLRs. The rationale behind this option is that I often have my exposures set to 30 seconds, which means that if there is no delay in between shots, I have no time to move my camera if I want to (since it'll just be a blurry mess if I do). I wasn't sure if this option would be useful for other types of cameras, nor would I be able to test it for other types of cameras, so I just left it for DSLRs.

Finally there were two tab characters I got rid of.

Thank you for this software!