### PR TITLE
Digital binoviewers/monocular support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ www-data/media/js/jsdb.js
 *.swp
 *.swo
 *.swn
+.idea

--- a/www-data/eyepiece.html
+++ b/www-data/eyepiece.html
@@ -199,17 +199,14 @@
             var leftEye = createEye();
             var rightEye = createEye();
 
-            // Calculate optimal eye size considering IPD (in pixels) and screen dimensions
-            var ipdPx = ipd;
-
             // Constraint 1: Circles must not intersect
             // Distance between centers = ipdPx, so radius must be <= ipdPx/2
-            var maxRadiusNoIntersect = ipdPx / 2;
+            var maxRadiusNoIntersect = ipd / 2;
 
             // Constraint 2: Circles must not overflow screen edges
             // Left circle: center at (screenWidth/2 - ipdPx/2), must fit: radius <= screenWidth/2 - ipdPx/2
             // Right circle: center at (screenWidth/2 + ipdPx/2), must fit: radius <= screenWidth/2 - ipdPx/2
-            var maxRadiusForScreenWidth = (screenWidth / 2) - (ipdPx / 2);
+            var maxRadiusForScreenWidth = (screenWidth / 2) - (ipd / 2);
 
             // Constraint 3: Height constraint
             var maxRadiusForHeight = screenHeight / 2;
@@ -218,7 +215,7 @@
             var radius = Math.min(maxRadiusNoIntersect, maxRadiusForScreenWidth, maxRadiusForHeight) * 0.98;
             var diameter = radius * 2;
 
-            debugLog('Screen:', screenWidth, 'x', screenHeight, 'IPD px:', ipdPx);
+            debugLog('Screen:', screenWidth, 'x', screenHeight, 'IPD px:', ipd);
             debugLog('Max radius - no intersect:', maxRadiusNoIntersect, 'screen width:', maxRadiusForScreenWidth, 'height:', maxRadiusForHeight);
             debugLog('Final radius:', radius);
 
@@ -228,11 +225,11 @@
             rightEye.style.height = diameter + 'px';
 
             leftEye.style.top = '50%';
-            leftEye.style.left = 'calc(50% - ' + (ipdPx / 2) + 'px)';
+            leftEye.style.left = 'calc(50% - ' + (ipd / 2) + 'px)';
             leftEye.style.transform = 'translate(-50%, -50%)';
 
             rightEye.style.top = '50%';
-            rightEye.style.left = 'calc(50% + ' + (ipdPx / 2) + 'px)';
+            rightEye.style.left = 'calc(50% + ' + (ipd / 2) + 'px)';
             rightEye.style.transform = 'translate(-50%, -50%)';
 
             container.appendChild(leftEye);

--- a/www-data/eyepiece.html
+++ b/www-data/eyepiece.html
@@ -98,6 +98,11 @@
     var current_ipd = null;
     var current_stream = null;
     var current_debug = null;
+    var current_width = null;
+    var current_height = null;
+    var updateLayoutTimeout = null;
+    var last_status_data = null;
+    var last_config_data = null;
     var streamImage = new Image();
 
     function drawToCanvas(canvas, img) {
@@ -144,95 +149,108 @@
         requestAnimationFrame(render);
     }
 
+    function applyLayout() {
+        if (!last_config_data) return;
+        var statusData = last_status_data;
+        var data = last_config_data;
+
+        var stream = (statusData && statusData.status !== 'idle') ? 'stacked' : 'live';
+        var config = (data && data.value) || {};
+        // Handle both boolean and string values for binoviewers
+        var binoviewers = config.stack_binoviewers === true || config.stack_binoviewers === 'true';
+        var ipd = parseFloat(config.stack_ipd) || 500;
+        // Read debug_log from ols_data config
+        debugEnabled = (config.debug_log === true || config.debug_log === 'true') || false;
+
+        if (stream !== current_stream) {
+            streamImage.src = '/api/video/' + stream;
+        }
+
+        var screenWidth = window.innerWidth;
+        var screenHeight = window.innerHeight;
+
+        if (binoviewers === current_binoviewers && ipd === current_ipd && stream === current_stream && debugEnabled === current_debug &&
+            screenWidth === current_width && screenHeight === current_height) {
+            return;
+        }
+
+        current_binoviewers = binoviewers;
+        current_ipd = ipd;
+        current_stream = stream;
+        current_debug = debugEnabled;
+        current_width = screenWidth;
+        current_height = screenHeight;
+
+        var container = document.getElementById('container');
+        container.innerHTML = '';
+
+        if (!binoviewers) {
+            debugLog('Creating single eye layout');
+            var eye = createEye();
+            var size = 'min(98vw, 98vh)';
+            eye.style.width = size;
+            eye.style.height = size;
+            eye.style.top = '50%';
+            eye.style.left = '50%';
+            eye.style.transform = 'translate(-50%, -50%)';
+            container.appendChild(eye);
+        } else {
+            debugLog('Creating binoviewers layout with IPD (px):', ipd);
+            var leftEye = createEye();
+            var rightEye = createEye();
+
+            // Calculate optimal eye size considering IPD (in pixels) and screen dimensions
+            var ipdPx = ipd;
+
+            // Constraint 1: Circles must not intersect
+            // Distance between centers = ipdPx, so radius must be <= ipdPx/2
+            var maxRadiusNoIntersect = ipdPx / 2;
+
+            // Constraint 2: Circles must not overflow screen edges
+            // Left circle: center at (screenWidth/2 - ipdPx/2), must fit: radius <= screenWidth/2 - ipdPx/2
+            // Right circle: center at (screenWidth/2 + ipdPx/2), must fit: radius <= screenWidth/2 - ipdPx/2
+            var maxRadiusForScreenWidth = (screenWidth / 2) - (ipdPx / 2);
+
+            // Constraint 3: Height constraint
+            var maxRadiusForHeight = screenHeight / 2;
+
+            // Use the smallest constraint with 2% margin
+            var radius = Math.min(maxRadiusNoIntersect, maxRadiusForScreenWidth, maxRadiusForHeight) * 0.98;
+            var diameter = radius * 2;
+
+            debugLog('Screen:', screenWidth, 'x', screenHeight, 'IPD px:', ipdPx);
+            debugLog('Max radius - no intersect:', maxRadiusNoIntersect, 'screen width:', maxRadiusForScreenWidth, 'height:', maxRadiusForHeight);
+            debugLog('Final radius:', radius);
+
+            leftEye.style.width = diameter + 'px';
+            leftEye.style.height = diameter + 'px';
+            rightEye.style.width = diameter + 'px';
+            rightEye.style.height = diameter + 'px';
+
+            leftEye.style.top = '50%';
+            leftEye.style.left = 'calc(50% - ' + (ipdPx / 2) + 'px)';
+            leftEye.style.transform = 'translate(-50%, -50%)';
+
+            rightEye.style.top = '50%';
+            rightEye.style.left = 'calc(50% + ' + (ipdPx / 2) + 'px)';
+            rightEye.style.transform = 'translate(-50%, -50%)';
+
+            container.appendChild(leftEye);
+            container.appendChild(rightEye);
+        }
+    }
+
     function updateLayout() {
+        if (updateLayoutTimeout) {
+            clearTimeout(updateLayoutTimeout);
+            updateLayoutTimeout = null;
+        }
         restCall('get', '/api/stacker/status', null, function (statusData) {
-            var stream = (statusData && statusData.status !== 'idle') ? 'stacked' : 'live';
-
             restCall('get', '/api/config/ols_data', null, function (data) {
-                var config = (data && data.value) || {};
-                // Handle both boolean and string values for binoviewers
-                var binoviewers = config.stack_binoviewers === true || config.stack_binoviewers === 'true';
-                var ipd = parseFloat(config.stack_ipd) || 500;
-                // Read debug_log from ols_data config
-                debugEnabled = (config.debug_log === true || config.debug_log === 'true') || false;
-                debugLog('Binoviewers config:', config.stack_binoviewers, 'parsed:', binoviewers);
-
-                if (stream !== current_stream) {
-                    streamImage.src = '/api/video/' + stream;
-                }
-
-                if (binoviewers === current_binoviewers && ipd === current_ipd && stream === current_stream && debugEnabled === current_debug) {
-                    setTimeout(updateLayout, 2000);
-                    return;
-                }
-
-                current_binoviewers = binoviewers;
-                current_ipd = ipd;
-                current_stream = stream;
-                current_debug = debugEnabled;
-
-                var container = document.getElementById('container');
-                container.innerHTML = '';
-
-                if (!binoviewers) {
-                    debugLog('Creating single eye layout');
-                    var eye = createEye();
-                    var size = 'min(98vw, 98vh)';
-                    eye.style.width = size;
-                    eye.style.height = size;
-                    eye.style.top = '50%';
-                    eye.style.left = '50%';
-                    eye.style.transform = 'translate(-50%, -50%)';
-                    container.appendChild(eye);
-                } else {
-                    debugLog('Creating binoviewers layout with IPD (px):', ipd);
-                    var leftEye = createEye();
-                    var rightEye = createEye();
-
-                    // Calculate optimal eye size considering IPD (in pixels) and screen dimensions
-                    var screenWidth = window.innerWidth;
-                    var screenHeight = window.innerHeight;
-
-                    // IPD is now passed as pixels directly
-                    var ipdPx = ipd;
-
-                    // Constraint 1: Circles must not intersect
-                    // Distance between centers = ipdPx, so radius must be <= ipdPx/2
-                    var maxRadiusNoIntersect = ipdPx / 2;
-
-                    // Constraint 2: Circles must not overflow screen edges
-                    // Left circle: center at (screenWidth/2 - ipdPx/2), must fit: radius <= screenWidth/2 - ipdPx/2
-                    // Right circle: center at (screenWidth/2 + ipdPx/2), must fit: radius <= screenWidth/2 - ipdPx/2
-                    var maxRadiusForScreenWidth = (screenWidth / 2) - (ipdPx / 2);
-
-                    // Constraint 3: Height constraint
-                    var maxRadiusForHeight = screenHeight / 2;
-
-                    // Use the smallest constraint with 2% margin
-                    var radius = Math.min(maxRadiusNoIntersect, maxRadiusForScreenWidth, maxRadiusForHeight) * 0.98;
-                    var diameter = radius * 2;
-
-                    debugLog('Screen:', screenWidth, 'x', screenHeight, 'IPD px:', ipdPx);
-                    debugLog('Max radius - no intersect:', maxRadiusNoIntersect, 'screen width:', maxRadiusForScreenWidth, 'height:', maxRadiusForHeight);
-                    debugLog('Final radius:', radius);
-
-                    leftEye.style.width = diameter + 'px';
-                    leftEye.style.height = diameter + 'px';
-                    rightEye.style.width = diameter + 'px';
-                    rightEye.style.height = diameter + 'px';
-
-                    leftEye.style.top = '50%';
-                    leftEye.style.left = 'calc(50% - ' + (ipdPx / 2) + 'px)';
-                    leftEye.style.transform = 'translate(-50%, -50%)';
-
-                    rightEye.style.top = '50%';
-                    rightEye.style.left = 'calc(50% + ' + (ipdPx / 2) + 'px)';
-                    rightEye.style.transform = 'translate(-50%, -50%)';
-
-                    container.appendChild(leftEye);
-                    container.appendChild(rightEye);
-                }
-                setTimeout(updateLayout, 2000);
+                last_status_data = statusData;
+                last_config_data = data;
+                applyLayout();
+                updateLayoutTimeout = setTimeout(updateLayout, 2000);
             });
         });
     }
@@ -249,6 +267,10 @@
     window.onload = function () {
         updateLayout();
         requestAnimationFrame(render);
+    };
+
+    window.onresize = function () {
+        applyLayout();
     };
 </script>
 </body>

--- a/www-data/eyepiece.html
+++ b/www-data/eyepiece.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta charset="UTF-8">
+    <link rel="icon" type="image/x-icon" href="/media/img/facicon.png" >
+    <title>OpenLiveStacker Eyepiece</title>
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            background-color: black;
+            overflow: hidden;
+        }
+
+        #container {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .eye-container {
+            position: absolute;
+            overflow: hidden;
+            border-radius: 50%;
+            border: 5px solid red; /* DEBUG: red ring to visualize positioning */
+        }
+
+        .eye-canvas {
+            width: 100%;
+            height: 100%;
+            display: block;
+        }
+    </style>
+</head>
+<body>
+<div id="container"></div>
+
+<script>
+    // Debug logging - enabled when OLS_DEBUG config is set
+    var debugEnabled = false;
+    function debugLog() {
+        if (debugEnabled) {
+            console.log.apply(console, arguments);
+        }
+    }
+
+    function restCall(method, url, request, on_response) {
+        var xhr = new XMLHttpRequest();
+        xhr.open(method, url, true);
+        xhr.timeout = 5000;
+        xhr.onload = function () {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                try {
+                    var response = JSON.parse(xhr.responseText);
+                    if (response.status === 'fail') {
+                        console.error("API error on " + url, response.error);
+                        on_response(null);
+                    } else {
+                        on_response(response);
+                    }
+                } catch (e) {
+                    console.error("Failed to parse response from " + url, e);
+                    on_response(null);
+                }
+            } else {
+                console.error("HTTP error on " + url, xhr.status);
+                on_response(null);
+            }
+        };
+        xhr.onerror = function () {
+            console.error("Network error on " + url);
+            on_response(null);
+        };
+        xhr.ontimeout = function () {
+            console.error("Timeout on " + url);
+            on_response(null);
+        };
+        if (request) {
+            xhr.setRequestHeader('Content-Type', 'application/json');
+            xhr.send(JSON.stringify(request));
+        } else {
+            xhr.send();
+        }
+    }
+
+    var current_binoviewers = null;
+    var current_ipd = null;
+    var current_stream = null;
+    var streamImage = new Image();
+
+    function drawToCanvas(canvas, img) {
+        if (!img.complete || img.naturalWidth === 0) return;
+
+        var rect = canvas.getBoundingClientRect();
+        var cw = Math.floor(rect.width);
+        var ch = Math.floor(rect.height);
+        if (cw === 0 || ch === 0) return;
+
+        if (canvas.width !== cw || canvas.height !== ch) {
+            canvas.width = cw;
+            canvas.height = ch;
+        }
+
+        var ctx = canvas.getContext('2d');
+        var iw = img.naturalWidth;
+        var ih = img.naturalHeight;
+
+        var iRatio = iw / ih;
+        var cRatio = cw / ch;
+
+        var sw, sh, sx, sy;
+        if (iRatio > cRatio) {
+            sh = ih;
+            sw = ih * cRatio;
+            sx = (iw - sw) / 2;
+            sy = 0;
+        } else {
+            sw = iw;
+            sh = iw / cRatio;
+            sx = 0;
+            sy = (ih - sh) / 2;
+        }
+
+        ctx.drawImage(img, sx, sy, sw, sh, 0, 0, cw, ch);
+    }
+
+    function render() {
+        var canvases = document.getElementsByClassName('eye-canvas');
+        if (canvases.length > 1) {
+            debugLog('Rendering to', canvases.length, 'canvases');
+        }
+        for (var i = 0; i < canvases.length; i++) {
+            drawToCanvas(canvases[i], streamImage);
+        }
+        requestAnimationFrame(render);
+    }
+
+    function updateLayout() {
+        restCall('get', '/api/stacker/status', null, function (statusData) {
+            var stream = (statusData && statusData.status !== 'idle') ? 'stacked' : 'live';
+            restCall('get', '/api/config/ols_data', null, function (data) {
+                var config = (data && data.value) || {};
+                // Handle both boolean and string values for binoviewers
+                var binoviewers = config.stack_binoviewers === true || config.stack_binoviewers === 'true';
+                var ipd = parseFloat(config.stack_ipd) || 500;
+                debugEnabled = config.ols_debug === true || config.ols_debug === 'true';
+                debugLog('Binoviewers config:', config.stack_binoviewers, 'parsed:', binoviewers);
+
+                if (stream !== current_stream) {
+                    streamImage.src = '/api/video/' + stream;
+                }
+
+                if (binoviewers === current_binoviewers && ipd === current_ipd && stream === current_stream) {
+                    setTimeout(updateLayout, 2000);
+                    return;
+                }
+                current_binoviewers = binoviewers;
+                current_ipd = ipd;
+                current_stream = stream;
+
+                var container = document.getElementById('container');
+                container.innerHTML = '';
+
+                if (!binoviewers) {
+                    debugLog('Creating single eye layout');
+                    var eye = createEye();
+                    var size = 'min(98vw, 98vh)';
+                    eye.style.width = size;
+                    eye.style.height = size;
+                    eye.style.top = '50%';
+                    eye.style.left = '50%';
+                    eye.style.transform = 'translate(-50%, -50%)';
+                    container.appendChild(eye);
+                } else {
+                    debugLog('Creating binoviewers layout with IPD (px):', ipd);
+                    var leftEye = createEye();
+                    var rightEye = createEye();
+
+                    // Calculate optimal eye size considering IPD (in pixels) and screen dimensions
+                    var screenWidth = window.innerWidth;
+                    var screenHeight = window.innerHeight;
+
+                    // IPD is now passed as pixels directly
+                    var ipdPx = ipd;
+
+                    // Constraint 1: Circles must not intersect
+                    // Distance between centers = ipdPx, so radius must be <= ipdPx/2
+                    var maxRadiusNoIntersect = ipdPx / 2;
+
+                    // Constraint 2: Circles must not overflow screen edges
+                    // Left circle: center at (screenWidth/2 - ipdPx/2), must fit: radius <= screenWidth/2 - ipdPx/2
+                    // Right circle: center at (screenWidth/2 + ipdPx/2), must fit: radius <= screenWidth/2 - ipdPx/2
+                    var maxRadiusForScreenWidth = (screenWidth / 2) - (ipdPx / 2);
+
+                    // Constraint 3: Height constraint
+                    var maxRadiusForHeight = screenHeight / 2;
+
+                    // Use the smallest constraint with 2% margin
+                    var radius = Math.min(maxRadiusNoIntersect, maxRadiusForScreenWidth, maxRadiusForHeight) * 0.98;
+                    var diameter = radius * 2;
+
+                    debugLog('Screen:', screenWidth, 'x', screenHeight, 'IPD px:', ipdPx);
+                    debugLog('Max radius - no intersect:', maxRadiusNoIntersect, 'screen width:', maxRadiusForScreenWidth, 'height:', maxRadiusForHeight);
+                    debugLog('Final radius:', radius);
+
+                    leftEye.style.width = diameter + 'px';
+                    leftEye.style.height = diameter + 'px';
+                    rightEye.style.width = diameter + 'px';
+                    rightEye.style.height = diameter + 'px';
+
+                    leftEye.style.top = '50%';
+                    leftEye.style.left = 'calc(50% - ' + (ipdPx / 2) + 'px)';
+                    leftEye.style.transform = 'translate(-50%, -50%)';
+
+                    rightEye.style.top = '50%';
+                    rightEye.style.left = 'calc(50% + ' + (ipdPx / 2) + 'px)';
+                    rightEye.style.transform = 'translate(-50%, -50%)';
+
+                    container.appendChild(leftEye);
+                    container.appendChild(rightEye);
+                }
+                setTimeout(updateLayout, 2000);
+            });
+        });
+    }
+
+    function createEye() {
+        var div = document.createElement('div');
+        div.className = 'eye-container';
+        var canvas = document.createElement('canvas');
+        canvas.className = 'eye-canvas';
+        div.appendChild(canvas);
+        return div;
+    }
+
+    window.onload = function() {
+        updateLayout();
+        requestAnimationFrame(render);
+    };
+</script>
+</body>
+</html>

--- a/www-data/eyepiece.html
+++ b/www-data/eyepiece.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
     <meta charset="UTF-8">
-    <link rel="icon" type="image/x-icon" href="/media/img/facicon.png" >
+    <link rel="icon" type="image/x-icon" href="/media/img/facicon.png">
     <title>OpenLiveStacker Eyepiece</title>
     <style>
         body, html {
@@ -28,7 +28,10 @@
             position: absolute;
             overflow: hidden;
             border-radius: 50%;
-            border: 5px solid red; /* DEBUG: red ring to visualize positioning */
+        }
+
+        .eye-container.debug {
+            border: 5px solid red; /* DEBUG: red ring to visualize positioning of the eyepiece circle */
         }
 
         .eye-canvas {
@@ -42,8 +45,10 @@
 <div id="container"></div>
 
 <script>
-    // Debug logging - enabled when OLS_DEBUG config is set
+    /** Debug logging is set in ./build/config.json
+     * "ols_data": { "debug_log": true, } */
     var debugEnabled = false;
+
     function debugLog() {
         if (debugEnabled) {
             console.log.apply(console, arguments);
@@ -92,6 +97,7 @@
     var current_binoviewers = null;
     var current_ipd = null;
     var current_stream = null;
+    var current_debug = null;
     var streamImage = new Image();
 
     function drawToCanvas(canvas, img) {
@@ -132,9 +138,6 @@
 
     function render() {
         var canvases = document.getElementsByClassName('eye-canvas');
-        if (canvases.length > 1) {
-            debugLog('Rendering to', canvases.length, 'canvases');
-        }
         for (var i = 0; i < canvases.length; i++) {
             drawToCanvas(canvases[i], streamImage);
         }
@@ -144,25 +147,29 @@
     function updateLayout() {
         restCall('get', '/api/stacker/status', null, function (statusData) {
             var stream = (statusData && statusData.status !== 'idle') ? 'stacked' : 'live';
+
             restCall('get', '/api/config/ols_data', null, function (data) {
                 var config = (data && data.value) || {};
                 // Handle both boolean and string values for binoviewers
                 var binoviewers = config.stack_binoviewers === true || config.stack_binoviewers === 'true';
                 var ipd = parseFloat(config.stack_ipd) || 500;
-                debugEnabled = config.ols_debug === true || config.ols_debug === 'true';
+                // Read debug_log from ols_data config
+                debugEnabled = (config.debug_log === true || config.debug_log === 'true') || false;
                 debugLog('Binoviewers config:', config.stack_binoviewers, 'parsed:', binoviewers);
 
                 if (stream !== current_stream) {
                     streamImage.src = '/api/video/' + stream;
                 }
 
-                if (binoviewers === current_binoviewers && ipd === current_ipd && stream === current_stream) {
+                if (binoviewers === current_binoviewers && ipd === current_ipd && stream === current_stream && debugEnabled === current_debug) {
                     setTimeout(updateLayout, 2000);
                     return;
                 }
+
                 current_binoviewers = binoviewers;
                 current_ipd = ipd;
                 current_stream = stream;
+                current_debug = debugEnabled;
 
                 var container = document.getElementById('container');
                 container.innerHTML = '';
@@ -232,14 +239,14 @@
 
     function createEye() {
         var div = document.createElement('div');
-        div.className = 'eye-container';
+        div.className = debugEnabled ? 'eye-container debug' : 'eye-container';
         var canvas = document.createElement('canvas');
         canvas.className = 'eye-canvas';
         div.appendChild(canvas);
         return div;
     }
 
-    window.onload = function() {
+    window.onload = function () {
         updateLayout();
         requestAnimationFrame(render);
     };

--- a/www-data/index.html
+++ b/www-data/index.html
@@ -303,6 +303,12 @@
         <p>
             <span id="extra_opt_toggle" class="nowr" ><label for="extra_opt_checked">Alpha Features</label><input class = "saved_input" id="extra_opt_checked" type="checkbox" onchange="enableAlphaFeatures(this.checked)" ></span>
         </p>
+        <p>
+            <span class="nowr" ><label for="stack_binoviewers">Binoviewers</label><input class="saved_input" id="stack_binoviewers" type="checkbox" onchange="toggleBinoviewers(this.checked)" ></span>
+        </p>
+        <p id="ipd_row" style="display:none">
+            <span class="nowr" >Interpupillary Distance (px):<input class="saved_input val_input" id="stack_ipd" type="number" value="500"></span>
+        </p>
         <p><button id="manual_geolocation" onclick="getBrowserGeolocation();">Get Geolocation</button></p>
         <p>
             <select id="font_size_ctl" class="saved_input" onchange="updateFontSize()">

--- a/www-data/media/js/code.js
+++ b/www-data/media/js/code.js
@@ -246,6 +246,10 @@ function updateSavedInputs()
             }
             el.dispatchEvent(new Event("input"));
             el.dispatchEvent(new Event("change"));
+            // Also trigger onchange attribute handler if present (dispatchEvent doesn't trigger attribute handlers)
+            if(el.onchange) {
+                el.onchange();
+            }
         }
         el.addEventListener('input',(e)=> { saveInputValue(e.currentTarget.id); });
     }
@@ -2106,6 +2110,11 @@ function toggleFS(fs)
     else {
         document.exitFullscreen();
     }
+}
+
+function toggleBinoviewers(checked)
+{
+    document.getElementById('ipd_row').style.display = checked ? '' : 'none';
 }
 
 


### PR DESCRIPTION
Something similar [to this post on cloudy nights](https://www.cloudynights.com/forums/topic/934172-my-dream-eaa-setup-with-digital-binocular-eyepiece/), but with the use of OLS.

What changed in codebase:
- An additional `eyepiece.html` is added without any control to show only the stacked / live image from OLS
- "Binoviewers" checkbox is added on the settings page
- * If enabled, then interpupillary distance can be adjusted to move images according to the user's needs
- * If disabled - only 1 eyepiece is rendered (should be useful for a single eyepiece setsup)
- Enabling debug logging also enables rendering of round boundaries around eyepiece images

<img width="1078" height="1094" alt="Screenshot from 2026-01-23 17-35-44" src="https://github.com/user-attachments/assets/360db770-7703-47db-8668-cfc8c71d47df" />

<img width="1078" height="1094" alt="Screenshot from 2026-01-23 17-35-49" src="https://github.com/user-attachments/assets/7589ca4a-c407-4510-9b19-de0f6322a0cc" />

<img width="2695" height="1598" alt="Screenshot from 2026-01-23 17-37-50" src="https://github.com/user-attachments/assets/41290ae2-da0d-4546-9645-fc3564c1e66e" />

<img width="2897" height="1746" alt="Screenshot from 2026-01-23 17-39-55" src="https://github.com/user-attachments/assets/181ad600-11e4-4ffd-b6df-c9d237d24a31" />

<img width="2897" height="1746" alt="Screenshot from 2026-01-23 17-40-32" src="https://github.com/user-attachments/assets/c8cf2e00-63e5-4a22-8e19-2368a5bf22e4" />

